### PR TITLE
Fix wrong sign condition check

### DIFF
--- a/z80.c
+++ b/z80.c
@@ -298,7 +298,7 @@ static int condition(Z80Context* ctx, Z80Condition cond)
 		return GETFLAG(F_S);
 	
 	if (cond == C_P)
-		return !GETFLAG(F_S | F_Z);
+		return !GETFLAG(F_S);
 		
 	if (cond == C_PE)
 		return GETFLAG(F_PV);


### PR DESCRIPTION
Fix wrong sign condition check (C_P) in condition() function. 

The condition only depends on the sign flag (F_S) (see description of JP cc,nn opcode in the Z80 user manual p. 239).
