### PR TITLE
Fix C++ linkage

### DIFF
--- a/z80.h
+++ b/z80.h
@@ -26,6 +26,13 @@
 #ifndef _Z80_H_
 #define _Z80_H_
 
+/* If this file is included inside a C++ program, use explicit C linkage for the following functions
+ * to avoid name mangling and liker issues
+ */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "stdio.h"
 
 typedef unsigned short ushort;
@@ -162,5 +169,8 @@ void Z80INT (Z80Context* ctx, byte value);
 /** Generates a non-maskable interrupt. */
 void Z80NMI (Z80Context* ctx);
 
+#ifdef __cplusplus
+} /*close extern "C" block*/
+#endif
 
 #endif


### PR DESCRIPTION
C code works "out of the box" in C++, but to link a valid executable, C functions needs to be declared as `extern "C"`.

This patch adds a preprocessor define (only active when header is  `#include`d by a C++ compiler) enclosing the definitions in an `extern "C"` block, fixing linkage errors on all platforms.

Also adds relevant comments explaining the presence of the `extern "C"` block.