### PR TITLE
get rid of "implicit declaration of function is...()" warnings

### DIFF
--- a/codegen/mktables.c
+++ b/codegen/mktables.c
@@ -15,6 +15,7 @@
 #include "regex.h"
 #include "stdlib.h"
 #include "string.h"
+#include "ctype.h"
 
 
 /* =========================================================


### PR DESCRIPTION
The functions isspace(), isupper(), is[x]digit() were declared implicitely (i.e. the header file was missing), leading to compiler warnings such as the following:

```
gcc -g -o mktables mktables.c
mktables.c: In function ‘printCall’:
mktables.c:215:9: warning: implicit declaration of function ‘isspace’ [-Wimplicit-function-declaration]
  while (isspace(*p) && (*p))
         ^
```

By including the correct header "ctype.h", the warnings are gone.