### PR TITLE
Replace gcc in makefiles with $(CC)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SOURCES = z80.c
-FLAGS = -fPIC -Wall -ansi -g
+FLAGS = -fPIC -Wall -std=c89 -g
 
 force: clean all
 
@@ -7,7 +7,7 @@ all: libz80.so
 
 libz80.so: z80.h $(OBJS)
 	cd codegen && make opcodes
-	gcc $(FLAGS) -shared -o libz80.so $(SOURCES)
+	$(CC) $(FLAGS) -shared -o libz80.so $(SOURCES)
 
 install:
 	install -m 666 libz80.so /usr/lib

--- a/codegen/Makefile
+++ b/codegen/Makefile
@@ -1,7 +1,7 @@
 all: mktables
 
 mktables: mktables.c
-	gcc -g -o mktables mktables.c
+	$(CC) -g -o mktables mktables.c
 	
 force: clean opcodes
 	

--- a/fuse_tests/Makefile
+++ b/fuse_tests/Makefile
@@ -11,4 +11,4 @@ tests.expected: fuse_files/tests.expected
 	./generate_expected.sh $< $@
 
 coretest: coretest.c
-	gcc -Wall -ansi -g -o $@ $< ../libz80.so
+	$(CC) -Wall -std=c89 -g -o $@ $< ../libz80.so


### PR DESCRIPTION
This commit allows other compilers besides gcc.

N.B. the "-ansi" flag is not supported in tcc, so this flag is
replaced with "-std=c89", which produces the same behavior as
"-ansi" in gcc and does not cause problems with tcc.